### PR TITLE
Pyarrow refactor

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ flask-session
 apache-airflow-providers-postgres
 apache-airflow[celery,postgres,s3,http,ssh]==2.9.2
 paramiko<3.0
+notebook

--- a/src/api_ingestion/birds/ebird_daily.py
+++ b/src/api_ingestion/birds/ebird_daily.py
@@ -47,7 +47,7 @@ def process_ebird_daily(data, region_code, target_date, timestamp, url):
     metadata = {
         '_source': 'eBird API',
         '_source_url': url,
-        '_ingestion_timestamp_utc': timestamp,
+        '_ingested_at_utc': timestamp,
     }
 
     observations_buffer = convert_data_to_parquet(data, metadata)

--- a/src/api_ingestion/birds/ebird_daily.py
+++ b/src/api_ingestion/birds/ebird_daily.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta, timezone
 from src.utils.logging_utils import setup_logger
 from src.utils.date_utils import get_current_utc_timestamp, get_pacific_target_date
 from src.utils.storage_utils import upload_parquet_to_minio
+from src.utils.file_utils import convert_data_to_parquet
 from src.config.app_settings import (
     LOG_FILE,
     EBIRD_API_KEY, 
@@ -40,20 +41,26 @@ def get_recent_observations_by_region(region_code, base_url=EBIRD_BASE_URL, api_
 
     return response.json(), url
 
-def convert_json_to_parquet(data, timestamp, source_url):
-    bird_data = pd.DataFrame(data)
-    bird_data['_ingestion_timestamp_utc'] = timestamp
-    bird_data['_source'] = source_url
+def process_ebird_daily(data, region_code, target_date, timestamp, url):
+    logger.info(f'Converting eBird API data to Parquet format')
 
-    buffer = BytesIO()
-    bird_data.to_parquet(buffer, index=False)
-    buffer.seek(0)
-    return buffer
+    metadata = {
+        '_source': 'eBird API',
+        '_source_url': url,
+        '_ingestion_timestamp_utc': timestamp,
+    }
+
+    observations_buffer = convert_data_to_parquet(data, metadata)
+
+    logger.info(f'Uploading Parquet file to MinIO')
+    file_name = f'ebird_observations_{region_code}.parquet'
+    object_name=f'birds/observations/source=ebird/region={region_code}/frequency=daily/date={target_date}/{file_name}'
+    upload_parquet_to_minio(observations_buffer, object_name=object_name, bucket_name=MINIO_RAW_BUCKET_NAME, logger=logger)
 
 def main():
     timestamp = get_current_utc_timestamp('%Y-%m-%dT%H:%M:%S')
 
-    target_date = get_pacific_target_date('%Y-%m-%d', 3)
+    target_date = get_pacific_target_date('%Y-%m-%d', days_ago=3)
     logger.info(f'Starting eBird API ingestion for {target_date}')
 
     logger.info(f'Fetching eBird API recent observation data')
@@ -73,14 +80,9 @@ def main():
     if not observations:
         logger.warning(f'No recent observations found for region: "{region_code}"')
         return
+    else:
+        process_ebird_daily(observations, region_code, target_date, timestamp, url)
 
-    logger.info(f'Converting eBird API data to Parquet format')
-    observations_buffer = convert_json_to_parquet(observations, timestamp, url)
-
-    logger.info(f'Uploading Parquet file to MinIO')
-    file_name = f'ebird_observations_{region_code}.parquet'
-    object_name=f'birds/observations/source=ebird/region={region_code}/daily/date={target_date}/{file_name}'
-    upload_parquet_to_minio(observations_buffer, object_name=object_name, bucket_name=MINIO_RAW_BUCKET_NAME, logger=logger)
 
 
 if __name__ == "__main__":

--- a/src/api_ingestion/birds/inaturalist_daily.py
+++ b/src/api_ingestion/birds/inaturalist_daily.py
@@ -13,7 +13,8 @@ from src.config.app_settings import (
     CA_REGION_CODE,
     CA_HOTSPOTS_BY_CENTER_POINT_COORDINATES,
     BIRDS_TAXON_NAME,
-    MINIO_RAW_BUCKET_NAME
+    MINIO_RAW_BUCKET_NAME,
+    INATURALIST_BASE_URL
 )
 
 log_name = os.path.basename(__file__)
@@ -69,7 +70,7 @@ def get_inaturalist_observations_by_coordinates(
 
     return observations
 
-def convert_json_to_parquet_bytes(data):
+def convert_json_to_parquet_bytes(data, timestamp):
     logger.info('Converting JSON data to Parquet format using Pandas')
 
     try:
@@ -77,8 +78,11 @@ def convert_json_to_parquet_bytes(data):
         observations = to_dataframe(data)
 
         # Normalize datetime columns
-        if 'observed_on' in observations.columns:
-            observations['observed_on'] = pd.to_datetime(observations['observed_on'], errors='coerce', utc=True)
+        # if 'observed_on' in observations.columns:
+        #     observations['observed_on'] = pd.to_datetime(observations['observed_on'], errors='coerce', utc=True)
+        observations['_source'] = 'iNaturalist API'
+        observations['_ingested_at_utc'] = timestamp
+        observations['_source_base_url'] = INATURALIST_BASE_URL
 
         parquet_buffer = BytesIO()
         # Write DataFrame to Parquet (in-memory)
@@ -119,11 +123,11 @@ def main():
         logger.debug(f'Observations data sample: {observations[:2]}')  # Log first 2 observations for debugging
 
         logger.info(f'Converting observations JSON data to parquet bytes')
-        parquet_bytes = convert_json_to_parquet_bytes(observations)
+        parquet_bytes = convert_json_to_parquet_bytes(observations, timestamp)
     
         logger.info(f'Uploading observations Parquet data to MinIO')
         file_name = f'inaturalist_observations_{CA_REGION_CODE}_{hotspot_name}_{start_date}.parquet'
-        object_name=f'birds/observations/source=inaturalist/region={CA_REGION_CODE}/hotspot={hotspot_name}/daily/date={start_date}/{file_name}'
+        object_name=f'birds/observations/source=inaturalist/region={CA_REGION_CODE}/hotspot={hotspot_name}/frequency=daily/date={start_date}/{file_name}'
         upload_parquet_to_minio(parquet_bytes, object_name=object_name, bucket_name=MINIO_RAW_BUCKET_NAME, logger=logger)
 
 

--- a/src/api_ingestion/weather/nasa_firms_fire_daily.py
+++ b/src/api_ingestion/weather/nasa_firms_fire_daily.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta, timezone
 from src.utils.logging_utils import setup_logger, get_log_name
 from src.utils.date_utils import get_current_utc_timestamp
 from src.utils.storage_utils import upload_parquet_to_minio
+from src.utils.file_utils import convert_data_to_parquet
 from src.config.app_settings import (
     LOG_FILE,
     CA_REGION_CODE,
@@ -27,9 +28,10 @@ def fetch_nasa_firms_daily(url, date, timeout=20):
         response.raise_for_status()
 
         fire_data = pd.read_csv(StringIO(response.text))
+        # fire_data = response.content
 
         logger.info(f'fetched {len(fire_data)} records for date: {date}')
-        return fire_data, url
+        return fire_data
     
     except requests.Timeout:
         logger.error(f'Request timed out after {timeout} seconds')
@@ -40,42 +42,50 @@ def fetch_nasa_firms_daily(url, date, timeout=20):
     except Exception as e:
         logger.error(f'Unexpected error: {e}')
 
-def convert_csv_to_parquet(data, timestamp):
-    """Convert a DataFrame to a parquet BytesIO buffer."""
-    fire_data = pd.DataFrame(data)
-    fire_data['_ingestion_timestamp_utc'] = timestamp
 
-    buffer = BytesIO()
-    data.to_parquet(buffer, index=False)
-    buffer.seek(0)
+def process_nasa_firms_data(data, url, timestamp, target_date):
+    """Process and upload NASA FIRMS data to MinIO as Parquet."""
+    logger.info(f'Starting to process NASA FIRMS data for upload to MinIO at ingestion time: {timestamp}')
 
-    return buffer
+    metadata = {
+        '_source': 'NASA FIRMS API',
+        '_source_url': url,
+        '_ingestion_timestamp_utc': timestamp,
+    }
+
+    logger.info(f'Converting NASA FIRMS data to Parquet for upload to MinIO at ingestion time: {timestamp}')
+    parquet_buffer = convert_data_to_parquet(data, metadata_columns=metadata)
+
+    logger.info(f'Uploading NASA FIRMS data to MinIO at ingestion time: {timestamp}')
+    file_name = f'nasa-firms_fire_{CA_REGION_CODE}_{target_date}.parquet'
+    object_name = f'weather/fire/source=nasa-firms/region={CA_REGION_CODE}/frequency=daily/date={target_date}/{file_name}'
+    try:
+        upload_parquet_to_minio(parquet_buffer, object_name=object_name, bucket_name=MINIO_RAW_BUCKET_NAME, logger=logger)
+        logger.info(f'Successfully uploaded NASA FIRMS data to MinIO at ingestion time: {timestamp} from url: "{url}"')
+    except Exception as e:
+        logger.error(f'Error uploading NASA FIRMS data to MinIO at ingestion time: {timestamp}: {e}')
+        raise
+
 
 def main():
 
     timestamp = get_current_utc_timestamp('%Y-%m-%dT%H:%M:%S')
     logger.info(f'Starting NASA FIRMS DAILY ingestion at {timestamp}')
 
-    # Get yesterday's date in UTC (timezone-aware) and format as 'YYYY-MM-DD'
-    target_date_str = (datetime.now(timezone.utc) - timedelta(days=3)).strftime('%Y-%m-%d')
+    target_date = (datetime.now(timezone.utc) - timedelta(days=3)).strftime('%Y-%m-%d')
+    url = f'{NASA_FIRMS_BASE_URL}/{NASA_FIRMS_API_KEY}/{NASA_FIRMS_DATA_SOURCE}/{CA_BBOX_COORDINATES}/1/{target_date}'
 
-    url = f'{NASA_FIRMS_BASE_URL}/{NASA_FIRMS_API_KEY}/{NASA_FIRMS_DATA_SOURCE}/{CA_BBOX_COORDINATES}/1/{target_date_str}'
-
-    fire_data, url = fetch_nasa_firms_daily(url, target_date_str)
+    try:
+        fire_data = fetch_nasa_firms_daily(url, target_date)
+    except Exception as e:
+        logger.error(f'Error fetching NASA FIRMS data: {e}')
+        return
 
     if fire_data is None or fire_data.empty:
-        logger.info('No data to upload.')
-        return
-    
-    fire_data['_ingestion_timestamp_utc'] = timestamp
-    fire_data['_source'] = url
+        logger.error('No data to upload.')
+    else:
+        process_nasa_firms_data(fire_data, url, timestamp, target_date)
 
-    parquet_buffer = convert_csv_to_parquet(fire_data, timestamp)
-
-    file_name = f'nasa-firms_fire_{CA_REGION_CODE}_{target_date_str}.parquet'
-    object_name = f'weather/fire/source=nasa-firms/region={CA_REGION_CODE}/daily/date={target_date_str}/{file_name}'
-
-    upload_parquet_to_minio(parquet_buffer, object_name=object_name, bucket_name=MINIO_RAW_BUCKET_NAME, logger=logger)
 
 if __name__ == '__main__':
     main()

--- a/src/api_ingestion/weather/nasa_firms_fire_daily.py
+++ b/src/api_ingestion/weather/nasa_firms_fire_daily.py
@@ -50,7 +50,7 @@ def process_nasa_firms_data(data, url, timestamp, target_date):
     metadata = {
         '_source': 'NASA FIRMS API',
         '_source_url': url,
-        '_ingestion_timestamp_utc': timestamp,
+        '_ingested_at_utc': timestamp,
     }
 
     logger.info(f'Converting NASA FIRMS data to Parquet for upload to MinIO at ingestion time: {timestamp}')

--- a/src/api_ingestion/weather/open_meteo_daily.py
+++ b/src/api_ingestion/weather/open_meteo_daily.py
@@ -15,7 +15,7 @@ if PROJECT_ROOT not in sys.path:
     sys.path.append(PROJECT_ROOT)
 
 from src.utils.logging_utils import setup_logger, get_log_name
-from src.utils.file_utils import convert_json_to_parquet, convert_nested_json_to_parquet
+from src.utils.file_utils import convert_nested_json_to_parquet
 from src.utils.date_utils import get_current_utc_timestamp, get_pacific_target_date
 from src.utils.storage_utils import upload_parquet_to_minio
 
@@ -60,8 +60,10 @@ def fetch_open_meteo_weather_daily(
 
         response.raise_for_status()
         weather = response.json()
+        request_url = response.url
 
-        return weather
+        return weather, request_url
+
     except RuntimeError as e:
         logger.error(f'Open Meteo: exceed retries. Error: {e}')
         raise
@@ -89,7 +91,7 @@ def fetch_open_meteo_coordinate_tiles(url, tiles_file_path, target_date, timesta
 
         try:
             logger.info(f'Fetching weather data for tile {tile_id} at ({latitude}, {longitude}) for date {target_date} at ingestion_time {timestamp_utc}')
-            weather = fetch_open_meteo_weather_daily(url, latitude, longitude, start_date, end_date)
+            weather, request_url = fetch_open_meteo_weather_daily(url, latitude, longitude, start_date, end_date)
             logger.info(f'Fetched weather for tile {tile_id} at ({latitude}, {longitude}) for date {target_date} at ingestion_time {timestamp_utc}')
         except Exception as e:
             logger.error(f'Error fetching weather for tile {tile_id} at ({latitude}, {longitude}) for date {target_date} at ingestion_time {timestamp_utc}: {e}')
@@ -99,17 +101,24 @@ def fetch_open_meteo_coordinate_tiles(url, tiles_file_path, target_date, timesta
             logger.info(f'No weather data found for tile {tile_id} at ({latitude}, {longitude}) for date {target_date} at ingestion_time {timestamp_utc}')
             continue
         else:
-            process_tile_weather_data(weather, tile_id, latitude, longitude, target_date, timestamp_utc)
+            process_tile_weather_data(weather, request_url, tile_id, latitude, longitude, target_date, timestamp_utc)
 
         time.sleep(0.2)
 
-def process_tile_weather_data(data, tile_id, latitude, longitude, target_date, timestamp_utc):
+def process_tile_weather_data(data, request_url, tile_id, latitude, longitude, target_date, timestamp_utc):
         logger.info(f'Converting weather data to Parquet for tile {tile_id} at ({latitude}, {longitude}) for date {target_date} at ingestion_time {timestamp_utc}')
-        weather_buffer = convert_nested_json_to_parquet(data)
+        
+        metadata = {
+            '_source': 'Open-Meteo API',
+            '_source_url': request_url,
+            '_ingestion_at': timestamp_utc,
+        }
+
+        weather_buffer = convert_nested_json_to_parquet(data, metadata_columns=metadata)
 
         logger.info(f'Uploading weather data to MinIO for tile {tile_id} at ({latitude}, {longitude}) for date {target_date} at ingestion_time {timestamp_utc}')
         file_name = f'open-meteo_weather_{CA_REGION_CODE}_{target_date}_tile-{tile_id}.parquet'
-        object_name = f'weather/general/source=open-meteo/region={CA_REGION_CODE}/daily/date={target_date}/grid_40km/tile={tile_id}/{file_name}'
+        object_name = f'weather/general/source=open-meteo/region={CA_REGION_CODE}/frequency=daily/date={target_date}/grid_size=40km/tile={tile_id}/{file_name}'
         upload_parquet_to_minio(weather_buffer, object_name=object_name, bucket_name='raw', logger=logger)
         logger.info(f'Successfully uploaded weather data to MinIO for tile {tile_id} at ({latitude}, {longitude}) for date {target_date} at ingestion_time {timestamp_utc}')
 

--- a/src/api_ingestion/weather/open_meteo_daily.py
+++ b/src/api_ingestion/weather/open_meteo_daily.py
@@ -111,7 +111,7 @@ def process_tile_weather_data(data, request_url, tile_id, latitude, longitude, t
         metadata = {
             '_source': 'Open-Meteo API',
             '_source_url': request_url,
-            '_ingestion_at': timestamp_utc,
+            '_ingestion_at_utc': timestamp_utc,
         }
 
         weather_buffer = convert_nested_json_to_parquet(data, metadata_columns=metadata)

--- a/src/api_ingestion/weather/open_meteo_daily.py
+++ b/src/api_ingestion/weather/open_meteo_daily.py
@@ -1,18 +1,23 @@
 import json, time, requests
 import pandas as pd
+import sys
 
-from src.utils.logging_utils import setup_logger, get_log_name
-from src.utils.file_utils import convert_json_to_parquet
-from src.utils.date_utils import get_current_utc_timestamp, get_pacific_target_date
-from src.utils.storage_utils import upload_parquet_to_minio
 from src.config.app_settings import (
     LOG_FILE,
+    PROJECT_ROOT,
     OPEN_METEO_BASE_URL,
     PACIFIC_TIMEZONE,
     CA_REGION_CODE,
     METEO_TILES_40KM_FILE_PATH as METEO_TILES_PATH,
     METEO_DAILY_PARAMS,
 )
+if PROJECT_ROOT not in sys.path:
+    sys.path.append(PROJECT_ROOT)
+
+from src.utils.logging_utils import setup_logger, get_log_name
+from src.utils.file_utils import convert_json_to_parquet, convert_nested_json_to_parquet
+from src.utils.date_utils import get_current_utc_timestamp, get_pacific_target_date
+from src.utils.storage_utils import upload_parquet_to_minio
 
 logger = setup_logger(get_log_name(__file__), LOG_FILE)
 
@@ -82,30 +87,25 @@ def fetch_open_meteo_coordinate_tiles(url, tiles_file_path, target_date, timesta
         latitude = tile['lat']
         longitude =  tile['lon']
 
-        logger.info(f'Fetching weather data for tile {tile_id} at ({latitude}, {longitude}) for date {target_date} at ingestion_time {timestamp_utc}')
-        weather = fetch_open_meteo_weather_daily(url, latitude, longitude, start_date, end_date)
-        logger.info(f'Fetched weather for tile {tile_id} at ({latitude}, {longitude}) for date {target_date} at ingestion_time {timestamp_utc}')
+        try:
+            logger.info(f'Fetching weather data for tile {tile_id} at ({latitude}, {longitude}) for date {target_date} at ingestion_time {timestamp_utc}')
+            weather = fetch_open_meteo_weather_daily(url, latitude, longitude, start_date, end_date)
+            logger.info(f'Fetched weather for tile {tile_id} at ({latitude}, {longitude}) for date {target_date} at ingestion_time {timestamp_utc}')
+        except Exception as e:
+            logger.error(f'Error fetching weather for tile {tile_id} at ({latitude}, {longitude}) for date {target_date} at ingestion_time {timestamp_utc}: {e}')
+            continue
 
         if not weather:
             logger.info(f'No weather data found for tile {tile_id} at ({latitude}, {longitude}) for date {target_date} at ingestion_time {timestamp_utc}')
             continue
-
-        process_tile_weather_data(weather, tile_id, latitude, longitude, target_date, timestamp_utc)
+        else:
+            process_tile_weather_data(weather, tile_id, latitude, longitude, target_date, timestamp_utc)
 
         time.sleep(0.2)
 
 def process_tile_weather_data(data, tile_id, latitude, longitude, target_date, timestamp_utc):
         logger.info(f'Converting weather data to Parquet for tile {tile_id} at ({latitude}, {longitude}) for date {target_date} at ingestion_time {timestamp_utc}')
-        
-        weather = pd.DataFrame(data['daily'])
-        weather['latitude'] = data['latitude']
-        weather['longitude'] = data['longitude']
-        weather['timezone'] = data['timezone']
-        weather['elevation'] = data['elevation']
-        weather['_ingested_at_utc'] = timestamp_utc
-        weather['_source'] = OPEN_METEO_BASE_URL
-        weather['_region'] = CA_REGION_CODE
-        weather_buffer = convert_json_to_parquet(weather)
+        weather_buffer = convert_nested_json_to_parquet(data)
 
         logger.info(f'Uploading weather data to MinIO for tile {tile_id} at ({latitude}, {longitude}) for date {target_date} at ingestion_time {timestamp_utc}')
         file_name = f'open-meteo_weather_{CA_REGION_CODE}_{target_date}_tile-{tile_id}.parquet'
@@ -118,7 +118,6 @@ def main():
     tiles_file_path = METEO_TILES_PATH
     target_date = get_pacific_target_date('%Y-%m-%d', days_ago=3)
     timestamp = get_current_utc_timestamp('%Y-%m-%dT%H:%M:%S')
-
 
     fetch_open_meteo_coordinate_tiles(url, tiles_file_path, target_date, timestamp)
 

--- a/src/config/app_settings.py
+++ b/src/config/app_settings.py
@@ -80,10 +80,12 @@ METEO_TILES_40KM_FILE_PATH = DATA_DIR / 'meteo_tiles_40km_sacramento_to_tulare.j
 METEO_DAILY_PARAMS = 'temperature_2m_max,temperature_2m_min,precipitation_sum,precipitation_hours,windspeed_10m_max,windgusts_10m_max,winddirection_10m_dominant,shortwave_radiation_sum,sunrise,sunset,rain_sum,weathercode,et0_fao_evapotranspiration'
 
 # Minio Credentials
-# MINIO_ENDPOINT = os.getenv('MINIO_URL_HOST_PORT') #local endpoint
-MINIO_ENDPOINT = os.getenv('MINIO_EXTERNAL_URL')  # Use this for local dev inside dev container
+MINIO_ENDPOINT = os.getenv('MINIO_URL_HOST_PORT') #local endpoint
+# MINIO_ENDPOINT = os.getenv('MINIO_EXTERNAL_URL')  # Use this for local dev inside dev container
 MINIO_DUCKDB_S3_ENDPOINT = os.getenv('MINIO_DUCKDB_S3_ENDPOINT_URL')
 MINIO_ACCESS_KEY = os.getenv('MINIO_ACCESS_KEY')
 MINIO_SECRET_KEY = os.getenv('MINIO_SECRET_KEY')
 MINIO_RAW_BUCKET_NAME = os.getenv('MINIO_RAW_BUCKET_NAME')
 MINIO_DUCKLAKE_BUCKET_NAME = os.getenv('MINIO_DUCKLAKE_BUCKET_NAME')
+
+INATURALIST_BASE_URL = 'https://api.inaturalist.org/v1/observations'

--- a/src/config/app_settings.py
+++ b/src/config/app_settings.py
@@ -80,7 +80,8 @@ METEO_TILES_40KM_FILE_PATH = DATA_DIR / 'meteo_tiles_40km_sacramento_to_tulare.j
 METEO_DAILY_PARAMS = 'temperature_2m_max,temperature_2m_min,precipitation_sum,precipitation_hours,windspeed_10m_max,windgusts_10m_max,winddirection_10m_dominant,shortwave_radiation_sum,sunrise,sunset,rain_sum,weathercode,et0_fao_evapotranspiration'
 
 # Minio Credentials
-MINIO_ENDPOINT = os.getenv('MINIO_URL_HOST_PORT')
+# MINIO_ENDPOINT = os.getenv('MINIO_URL_HOST_PORT') #local endpoint
+MINIO_ENDPOINT = os.getenv('MINIO_EXTERNAL_URL')  # Use this for local dev inside dev container
 MINIO_DUCKDB_S3_ENDPOINT = os.getenv('MINIO_DUCKDB_S3_ENDPOINT_URL')
 MINIO_ACCESS_KEY = os.getenv('MINIO_ACCESS_KEY')
 MINIO_SECRET_KEY = os.getenv('MINIO_SECRET_KEY')

--- a/src/utils/file_utils.py
+++ b/src/utils/file_utils.py
@@ -1,5 +1,8 @@
 from pathlib import Path
 import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+import io
 from io import BytesIO
 
 def ensure_directory_exists(path):
@@ -17,4 +20,19 @@ def convert_json_to_parquet(data):
     data.to_parquet(buffer, index=False)
     buffer.seek(0)
     
+    return buffer
+
+def convert_nested_json_to_parquet(data):
+    """
+    Convert nested JSON/dict (or list of dicts) to a Parquet buffer using PyArrow.
+    This preserves nested structs, lists, and maps.
+    """
+    if isinstance(data, dict):
+        # Wrap in a list so Arrow sees it as one row
+        data = [data]
+
+    table = pa.Table.from_pylist(data)
+    buffer = io.BytesIO()
+    pq.write_table(table, buffer, compression="zstd")  # or snappy, gzip, etc.
+    buffer.seek(0)
     return buffer

--- a/src/utils/file_utils.py
+++ b/src/utils/file_utils.py
@@ -12,27 +12,48 @@ def ensure_directory_exists(path):
     
     return path
 
-def convert_json_to_parquet(data):
-    if not isinstance(data, pd.DataFrame):
-        data = pd.DataFrame(data)
+# def convert_csv_to_parquet(data, timestamp):
+#     """Convert a DataFrame to a parquet BytesIO buffer."""
+#     fire_data = pd.DataFrame(data)
+#     fire_data['_ingestion_timestamp_utc'] = timestamp
 
-    buffer = BytesIO()
-    data.to_parquet(buffer, index=False)
-    buffer.seek(0)
+#     buffer = BytesIO()
+#     data.to_parquet(buffer, index=False)
+#     buffer.seek(0)
+
+#     return buffer
+
+# def convert_json_to_parquet(data):
+#     if not isinstance(data, pd.DataFrame):
+#         data = pd.DataFrame(data)
+
+#     buffer = BytesIO()
+#     data.to_parquet(buffer, index=False)
+#     buffer.seek(0)
     
-    return buffer
+#     return buffer
 
-def convert_nested_json_to_parquet(data):
+def convert_data_to_parquet(data, metadata_columns=None):
     """
     Convert nested JSON/dict (or list of dicts) to a Parquet buffer using PyArrow.
     This preserves nested structs, lists, and maps.
     """
     if isinstance(data, dict):
         # Wrap in a list so Arrow sees it as one row
-        data = [data]
+        data = [data]     
+    elif isinstance(data, pd.DataFrame):
+        data = data.to_dict(orient="records")
 
     table = pa.Table.from_pylist(data)
+    num_rows = table.num_rows
+
+    if metadata_columns:
+        for col, value in metadata_columns.items():
+            arr = pa.array([value] * num_rows)
+            table = table.append_column(col, arr)
+
     buffer = io.BytesIO()
-    pq.write_table(table, buffer, compression="zstd")  # or snappy, gzip, etc.
+    pq.write_table(table, buffer, compression="zstd")  # Other compression options: snappy, gzip
     buffer.seek(0)
+    
     return buffer


### PR DESCRIPTION
Combined csv and json convert to parquet functions into a single `utils.file_utils.convert_data_to_parquet` helper function
This function:
- Takes any data form and converts to Pyarrow Table, including nested value structures
- Accepts a metadata dict (any number of key/value pairs) and adds each key as a column with the value passed in
- Metadata columns include `_source`, `_source_url`, and `ingested_at` keys with source data type, fetch url, and utc ingestion timestamp values
- Converts to Parquet bytes
- Returns the bytes buffer

Revised `ebird_daily`, `nasa_firms_daily`, and `open_meteo_daily` scripts to use this function instead of `convert_json_to_parquet` or `convert_csv_to_parquet` functions
*Note: Ran into some more issues with the`inaturalist_daily` module due to the imported functions from `pyinaturalist` library - Will circle back to this later